### PR TITLE
Correcting plural of "Mediums" to "Media"

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -13,7 +13,7 @@
         "Names": "Campaign Names",
         "Keywords": "Campaign Keywords",
         "Sources": "Campaign Sources",
-        "Mediums": "Campaign Mediums",
+        "Mediums": "Campaign Media",
         "Contents": "Campaign Contents",
         "Groups": "Campaign Groups",
         "Placements": "Campaign Placements",


### PR DESCRIPTION
This change comes at the request of our marketing team, who are in charge of all the language and grammar on our website. They have pointed out that the correct plural of "Mediums" is "Media" in this context.